### PR TITLE
Fixed PostgisTrait to handle GeometryCollection correctly

### DIFF
--- a/src/Eloquent/PostgisTrait.php
+++ b/src/Eloquent/PostgisTrait.php
@@ -24,9 +24,12 @@ trait PostgisTrait
     protected function performInsert(EloquentBuilder $query, array $options = [])
     {
         foreach ($this->attributes as $key => &$value) {
-            if ($value instanceof GeometryInterface) {
+            if ($value instanceof GeometryInterface && ! $value instanceof GeometryCollection) {
                 $this->geometries[$key] = $value; //Preserve the geometry objects prior to the insert
                 $value = $this->getConnection()->raw(sprintf("ST_GeogFromText('%s')", $value->toWKT()));
+            }  else if ($value instanceof GeometryInterface && $value instanceof GeometryCollection) {
+                $this->geometries[$key] = $value; //Preserve the geometry objects prior to the insert
+                $value = $this->getConnection()->raw(sprintf("ST_GeomFromText('%s', 4326)", $value->toWKT()));
             }
         }
 


### PR DESCRIPTION
The geometrycollection migration method inserts the column as a geometry column instead of a geography column. This causes saves to fail since the insert is trying to save a geography instead of a geometry. 

The GeometryCollection class does extend the Geometry class which implements the GeometryInterface that is checked in the if statement to skip model attributes that are not geometries.